### PR TITLE
Add client-side JWT generation for Messenger Security testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <input type="text" id="user_name" placeholder="Enter your name">
         <input type="text" id="company_name" placeholder="Enter user company name">
         <input type="text" id="company_id" placeholder="Enter your company ID">
+        <input type="text" id="jwt_secret" placeholder="Enter JWT secret (for Messenger Security)">
     </form>
 
     <div id="button-block">

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -11,7 +11,34 @@ const user_ID = document.querySelector("#user_id");
 const user_name = document.querySelector("#user_name");
 const company_name = document.querySelector("#company_name")
 const company_id = document.querySelector("#company_id")
+const jwt_secret = document.querySelector("#jwt_secret")
 
+function base64url(buffer) {
+    const bytes = buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer;
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function generateJWT(secret, payload) {
+    const header = { alg: "HS256", typ: "JWT" };
+    const encoder = new TextEncoder();
+
+    const headerB64 = base64url(encoder.encode(JSON.stringify(header)));
+    const payloadB64 = base64url(encoder.encode(JSON.stringify(payload)));
+    const signingInput = `${headerB64}.${payloadB64}`;
+
+    const key = await crypto.subtle.importKey(
+        "raw",
+        encoder.encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"]
+    );
+
+    const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(signingInput));
+    return `${signingInput}.${base64url(signature)}`;
+}
 
 visit.addEventListener("click", () => {
     window.Intercom('boot', {
@@ -19,28 +46,34 @@ visit.addEventListener("click", () => {
     })
 })
 
-boot.addEventListener("click", ()=> {
-    if(company_name.value) {
-        window.Intercom('boot', {  
-            "app_id": `${app_ID.value}`,  
-            "email": `${email.value}`,
-            "user_id": `${user_ID.value}`,
-            "name": `${user_name.value}`,
-    
-            "company": {
-                "id": `${company_id.value}`,
-                "name": `${company_name.value}`
-            }
-        })
-    } else {
-        window.Intercom('boot', {  
-            "app_id": `${app_ID.value}`,  
-            "email": `${email.value}`,
-            "user_id": `${user_ID.value}`,
-            "name": `${user_name.value}`,
-        })
+boot.addEventListener("click", async () => {
+    let bootSettings = {
+        "app_id": app_ID.value,
+        "email": email.value,
+        "user_id": user_ID.value,
+        "name": user_name.value,
+    };
+
+    if (company_name.value) {
+        bootSettings.company = {
+            "id": company_id.value,
+            "name": company_name.value,
+        };
     }
-    
+
+    if (jwt_secret.value) {
+        const payload = {
+            user_id: user_ID.value,
+            exp: Math.floor(Date.now() / 1000) + 3600,
+        };
+        if (email.value) payload.email = email.value;
+
+        const token = await generateJWT(jwt_secret.value, payload);
+        bootSettings.intercom_user_jwt = token;
+        console.log("Generated JWT:", token);
+    }
+
+    window.Intercom('boot', bootSettings);
     console.log(`${user_name.value}`)
     console.log("clicked boot")
 })

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,14 @@ input:focus{
     background-color: transparent;
 }
 
+#jwt_secret {
+    border-color: #F7DC6F;
+}
+
+#jwt_secret:focus {
+    border-color: #F4D03F;
+}
+
 input:-webkit-autofill,
 input:-webkit-autofill:focus {
   transition: background-color 600000s 0s, color 600000s 0s;


### PR DESCRIPTION
### Why?

Currently there's no way to test Messenger Security with JWTs in PlanetExpress because there's no backend server to generate tokens. This means you have to set up a separate server or use an external tool every time you need to test JWT-secured Messenger installs.

### How?

Adds a JWT secret input field and uses the browser's Web Crypto API to generate HS256-signed JWTs client-side when the "Boot!" button is clicked. The JWT includes `user_id`, `email`, and a 1-hour `exp` claim, and is passed to the Messenger via `intercom_user_jwt`. When the secret field is left empty, the Messenger boots as before.

<sub>Generated with Claude Code</sub>