### PR TITLE
Fix Boot button to use boot method instead of update

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Asap:ital,wght@0,400;0,500;0,600;0,700;1,600&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/defb058ca4.js" crossorigin></script>
     <script>
-      // We pre-filled your app ID in the widget URL: 'https://widget.intercom.io/widget/n8r3m4pe'
-      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/n8r3m4pe';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+      // Set up Intercom stub only — widget script is loaded dynamically on boot
+      (function(){var w=window;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;})();
       </script> 
     <title>Planet Express</title>
 </head>

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -13,6 +13,22 @@ const company_name = document.querySelector("#company_name")
 const company_id = document.querySelector("#company_id")
 const jwt_secret = document.querySelector("#jwt_secret")
 
+function ensureIntercomLoaded(appId) {
+    return new Promise((resolve) => {
+        if (document.querySelector('script[src*="widget.intercom.io"]')) {
+            resolve();
+            return;
+        }
+        const s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.async = true;
+        s.src = `https://widget.intercom.io/widget/${appId}`;
+        s.onload = resolve;
+        const x = document.getElementsByTagName('script')[0];
+        x.parentNode.insertBefore(s, x);
+    });
+}
+
 function base64url(buffer) {
     const bytes = buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer;
     let binary = '';
@@ -40,13 +56,16 @@ async function generateJWT(secret, payload) {
     return `${signingInput}.${base64url(signature)}`;
 }
 
-visit.addEventListener("click", () => {
+visit.addEventListener("click", async () => {
+    await ensureIntercomLoaded(app_ID.value);
     window.Intercom('boot', {
-        "app_id": `${app_ID.value}`
+        "app_id": app_ID.value
     })
 })
 
 boot.addEventListener("click", async () => {
+    await ensureIntercomLoaded(app_ID.value);
+
     let bootSettings = {
         "app_id": app_ID.value,
         "email": email.value,


### PR DESCRIPTION
### Why?

The Intercom install snippet was auto-booting the Messenger on page load with a hardcoded app_id and calling `Intercom('update')`. This meant clicking "Boot!" was effectively updating an already-running Messenger rather than performing a fresh `Intercom('boot')` with the user's configured settings.

### How?

Replaced the full install snippet with a minimal Intercom stub and moved widget script loading into `app.js` where it's triggered dynamically when the user clicks Boot or To the Moon, using their specified app_id from the form.

<sub>Generated with Claude Code</sub>